### PR TITLE
Modified typings-redux reference to avoid mismatch on IAction

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -4,7 +4,7 @@
 	"ambient": false,
 	"dependencies": {
 		"history": "github:andrew-w-ross/typings-history",
-		"redux": "github:andrew-w-ross/typings-redux#e16683b6d921624478ff926c9b50151aa4a5d22d"
+		"redux": "github:andrew-w-ross/typings-redux#2e0b57e18c6240d17fde045573d74e649762437b"
 	},
 	"devDependencies": {
 		"react-redux": "github:andrew-w-ross/typings-react-redux#6be88a57427f8ec220cad13d68565fd5f5711146",


### PR DESCRIPTION
When using typings-react-router-redux, there is a mismatch on IAction:

```
test.tsx(115,12): error TS2322: Type 'IStore<IState>' is not assignable to type 'IStore<any>'.
  Types of property 'dispatch' are incompatible.
    Type 'redux.IDispatch' is not assignable to type 'redux.IDispatch'.
      Type 'redux.IAction' is not assignable to type 'redux.IAction'.
        Types of property 'type' are incompatible.
          Type 'string | number | Symbol' is not assignable to type 'string | number'.
            Type 'Symbol' is not assignable to type 'string | number'.
              Type 'Symbol' is not assignable to type 'number'.
```

typings.json has been modified to reference the most recent version of typings-redux.
